### PR TITLE
make OwinContext and HeaderDictionary public

### DIFF
--- a/Fos/Owin/HeaderDictionary.cs
+++ b/Fos/Owin/HeaderDictionary.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 
 namespace Fos
 {
-    internal class HeaderDictionary : IDictionary<string, string[]>
+    public class HeaderDictionary : IDictionary<string, string[]>
     {
         private Dictionary<string, string[]> Headers;
 

--- a/Fos/Owin/OwinContext.cs
+++ b/Fos/Owin/OwinContext.cs
@@ -8,7 +8,7 @@ using FastCgiNet.Streams;
 
 namespace Fos.Owin
 {
-	internal class OwinContext : IDictionary<string, object>
+	public class OwinContext : IDictionary<string, object>
 	{
 		/// <summary>
 		/// The parameters dictionary of the owin pipeline, built through this class's methods.
@@ -148,7 +148,7 @@ namespace Fos.Owin
 		}
 
         //private readonly static System.Text.RegularExpressions.Regex HttpHeaderRegex = new System.Text.RegularExpressions.Regex(@"HTTP_(([^ _])+(_?))+");
-		public void SetOwinParametersFromFastCgiNvp(NameValuePair nameValuePair)
+		internal void SetOwinParametersFromFastCgiNvp(NameValuePair nameValuePair)
 		{
             string nvpName = nameValuePair.Name;
 


### PR DESCRIPTION
Hi, shouldn't `OwinContext` and `HeaderDictionary` be public, so that `IAppBuilder` implementations can access them outside of the `Fos.DLL`, or do I miss something?