### PR TITLE
Headers are now written in the case of an empty output stream.

### DIFF
--- a/Fos/Listener/FosRequest.cs
+++ b/Fos/Listener/FosRequest.cs
@@ -188,6 +188,12 @@ namespace Fos.Listener
 				}
                 else
                 {
+                    // If no data has been written (e.g. 304 w/- empty response), the headers won't have been written
+                    if (stdout.Length == 0)
+                    {
+                        SendHeaders();
+                    }
+
                     // Signal successful return status
                     SendEndRequest(0, ProtocolStatus.RequestComplete);
                 }


### PR DESCRIPTION
If the output stream has not been written to, the OnFirstWrite event is never fired, and therefore no headers are written.

This feels like a bit of a hack, but seems to work.